### PR TITLE
Update go.mod to declare module with lowercase letter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Galactica-corp/merkle-proof-service
+module github.com/galactica-corp/merkle-proof-service
 
 go 1.22.2
 


### PR DESCRIPTION
## Motivation

1. In Go naming conventions for modules are the same as for the packages, because module can provide code in it's root package;
2. Capital letters are discouraged to use in package names;
3. Actual module name is becoming mangled with exclamation marks;
4. GitHub organisation and repository URL parts are case insensitive.