### PR TITLE
fix: Use uint64 in maxLeaves function to prevent from overflow

### DIFF
--- a/internal/zkregistry/sparse_tree.go
+++ b/internal/zkregistry/sparse_tree.go
@@ -250,7 +250,7 @@ func (t *SparseMerkleTree) GetRandomEmptyLeafIndex(ctx context.Context) (TreeLea
 		default:
 		}
 
-		index := TreeLeafIndex(rand.Uint32() % t.maxLeaves())
+		index := TreeLeafIndex(rand.Uint64() % t.maxLeaves())
 
 		// check if the value are empty in the tree then return the index
 		if _, err := t.storageLeafGetter.GetLeaf(ctx, 0, index); errors.Is(err, types.ErrNotFound) {
@@ -359,7 +359,7 @@ func (t *SparseMerkleTree) getEmptyBranchValue(level TreeLevel) (*uint256.Int, e
 	return t.emptyBranchLevels[level], nil
 }
 
-func (t *SparseMerkleTree) maxLeaves() uint32 {
+func (t *SparseMerkleTree) maxLeaves() uint64 {
 	return 1 << t.depth // 2^depth
 }
 


### PR DESCRIPTION
```
panic: runtime error: integer divide by zero

goroutine 101 [running]:
github.com/Galactica-corp/merkle-proof-service/internal/zkregistry.(*SparseMerkleTree).GetRandomEmptyLeafIndex(0x1400009da40, {0x1034fe278, 0x14000253590})
	/Users/me/wrk/merkle-proof-service/internal/zkregistry/sparse_tree.go:253 +0x148
github.com/Galactica-corp/merkle-proof-service/internal/zkregistry.(*ZKCertificateRegistry).GetRandomEmptyLeafProof(0x14000282120, {0x1034fe278, 0x14000253590})
	/Users/me/wrk/merkle-proof-service/internal/zkregistry/zk_certificate_registry.go:128 +0x4c
github.com/Galactica-corp/merkle-proof-service/internal/query.(*Server).GetEmptyLeafProof(0x14000110108, {0x1034fe278, 0x14000253590}, 0x140007b3500)
	/Users/me/wrk/merkle-proof-service/internal/query/get_empty_index_handler.go:40 +0xa4
github.com/Galactica-corp/merkle-proof-service/gen/galactica/merkle._Query_GetEmptyLeafProof_Handler({0x10344a7c0, 0x14000110108}, {0x1034fe278, 0x14000253590}, 0x140007c2600, 0x0)
	/Users/me/wrk/merkle-proof-service/gen/galactica/merkle/query_grpc.pb.go:121 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x14000250000, {0x1034fe278, 0x14000442b10}, {0x103503e20, 0x14000482000}, 0x14000474000, 0x14000278300, 0x103a4f438, 0x0)
	/Users/me/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1369 +0xb58
google.golang.org/grpc.(*Server).handleStream(0x14000250000, {0x103503e20, 0x14000482000}, 0x14000474000)
	/Users/me/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1780 +0xb20
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/Users/me/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1019 +0x8c
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 100
	/Users/me/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1030 +0x13c
```

В sparse_tree.go:253: `index := TreeLeafIndex(rand.Uint32() % t.maxLeaves())`

```go
func (t *SparseMerkleTree) maxLeaves() uint32 {
	return 1 << t.depth // 2^depth
}
```

If the tree depth = 32, 1 << 32 = 4 294 967 296 which is 0 in uint32.