### PR TITLE
Polling indexation mode

### DIFF
--- a/config/merkle.yaml
+++ b/config/merkle.yaml
@@ -1,6 +1,7 @@
 log_level: debug
 
-evm_rpc: wss://evm-rpc-ws-andromeda.galactica.com
+#evm_rpc: wss://evm-rpc-ws-andromeda.galactica.com
+evm_rpc: https://evm-rpc-http-andromeda.galactica.com
 
 db_backend: pebbledb
 
@@ -11,9 +12,20 @@ grpc_gateway:
   address: localhost:8480
 
 indexer:
+  # The indexer mode can be either "poll" or "ws"
+  mode: poll
+
+  # The polling interval for the indexer when indexer mode is "poll"
+  polling_interval: 1s
+
+  # The maximum number of historical blocks to fetch from the indexer
   max_blocks_distance: 1000
+
+  # The maximum channel size for the logs from websocket
   sink_channel_size: 100
-  sink_progress_tick: 5s
+
+  # Duration to log the progress of the indexer when indexer mode is "ws"
+  sink_progress_tick: 10s
 
 # You can specify multiple contracts to watch
 zk_certificate_registry:

--- a/internal/indexer/ZkCertificateRegistry.go
+++ b/internal/indexer/ZkCertificateRegistry.go
@@ -262,6 +262,30 @@ func (job *ZkCertificateRegistryJob) getParserLazy() (*ZkCertificateRegistry.ZkC
 	return parser, err
 }
 
+// JobDescriptor returns the job descriptor.
+func (job *ZkCertificateRegistryJob) JobDescriptor() JobDescriptor {
+	return job.jobDescriptor
+}
+
+func (job *ZkCertificateRegistryJob) OnIndexerModeChange(mode Mode) {
+	progressTracker := job.registry.ProgressTracker()
+	if progressTracker == nil {
+		return
+	}
+
+	// no-op
+	switch mode {
+	case ModeWS, ModePoll:
+		if !progressTracker.IsOnHead() {
+			progressTracker.SetOnHead(true)
+		}
+	case ModeHistory:
+		if progressTracker.IsOnHead() {
+			progressTracker.SetOnHead(false)
+		}
+	}
+}
+
 // WithOperationsBuffer sets the leaves buffer in the context.
 func WithOperationsBuffer(ctx context.Context, buffer *zkregistry.OperationsBuffer) context.Context {
 	return context.WithValue(ctx, ctxOperationsBufferKey, buffer)

--- a/internal/indexer/configurator.go
+++ b/internal/indexer/configurator.go
@@ -216,7 +216,7 @@ func (c *Configurator) Wait() chan error {
 }
 
 // String returns a string representation of the Job.
-func (j *JobDescriptor) String() string {
+func (j JobDescriptor) String() string {
 	// address first 6 symbols and last 4 symbols:
 	address := j.Address.Hex()
 	return fmt.Sprintf(

--- a/internal/indexer/job_factory.go
+++ b/internal/indexer/job_factory.go
@@ -35,6 +35,8 @@ type (
 		HandleEVMLog(ctx context.Context, log types.Log) error
 		Commit(ctx context.Context, block uint64) error
 		FilterQuery() (ethereum.FilterQuery, error)
+		JobDescriptor() JobDescriptor
+		OnIndexerModeChange(mode Mode)
 	}
 
 	DBBatchCreator interface {

--- a/internal/indexer/job_storage.go
+++ b/internal/indexer/job_storage.go
@@ -147,7 +147,7 @@ func makeJobKey(job JobDescriptor) []byte {
 }
 
 // String returns a string representation of the Job.
-func (j *Job) String() string {
+func (j Job) String() string {
 	// address first 6 symbols and last 4 symbols:
 	address := j.Address.Hex()
 	return fmt.Sprintf(

--- a/internal/query/get_empty_index_handler.go
+++ b/internal/query/get_empty_index_handler.go
@@ -37,6 +37,10 @@ func (s *Server) GetEmptyLeafProof(ctx context.Context, req *merklegen.GetEmptyL
 		return nil, status.Errorf(codes.NotFound, "tree not found: %s", req.Registry)
 	}
 
+	if !registry.ProgressTracker().IsOnHead() {
+		return nil, status.Errorf(codes.FailedPrecondition, "registry indexer is not on head, try again later")
+	}
+
 	proofOfEmptyIndex, err := registry.GetRandomEmptyLeafProof(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get empty leaf proof, try again")

--- a/internal/zkregistry/progress.go
+++ b/internal/zkregistry/progress.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Galactica Network
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zkregistry
+
+import "sync/atomic"
+
+type (
+	Progress struct {
+		onHead uint32
+	}
+)
+
+func NewProgress() *Progress {
+	return &Progress{}
+}
+
+// IsOnHead returns true if the indexer is on the head of the chain.
+func (p *Progress) IsOnHead() bool {
+	return atomic.LoadUint32(&p.onHead) == 1
+}
+
+// SetOnHead sets the flag that the indexer is on the head of the chain.
+func (p *Progress) SetOnHead(onHead bool) {
+	if onHead {
+		atomic.StoreUint32(&p.onHead, 1)
+	} else {
+		atomic.StoreUint32(&p.onHead, 0)
+	}
+}

--- a/internal/zkregistry/service.go
+++ b/internal/zkregistry/service.go
@@ -156,7 +156,13 @@ func (s *Service) InitializeRegistry(ctx context.Context, address common.Address
 		return nil, fmt.Errorf("failed to create sparse tree: %w", err)
 	}
 
-	zkCertificateRegistry := NewZKCertificateRegistry(metadata, sparseTree, leafView, s.registryMutex.NewView(registryIndex))
+	zkCertificateRegistry := NewZKCertificateRegistry(
+		metadata,
+		sparseTree,
+		leafView,
+		s.registryMutex.NewView(registryIndex),
+		NewProgress(),
+	)
 
 	// cache the registry
 	s.registryMu.Lock()

--- a/internal/zkregistry/zk_certificate_registry.go
+++ b/internal/zkregistry/zk_certificate_registry.go
@@ -25,13 +25,19 @@ import (
 )
 
 type (
+	IndexerProgressTracker interface {
+		IsOnHead() bool
+		SetOnHead(onHead bool)
+	}
+
 	// ZKCertificateRegistry represents a zk certificate registry for a specific address.
 	// It provides methods to interact with the merkle tree.
 	ZKCertificateRegistry struct {
-		metadata   Metadata
-		sparseTree *SparseMerkleTree
-		leafView   *LeafView
-		mutex      *MutexView
+		metadata        Metadata
+		sparseTree      *SparseMerkleTree
+		leafView        *LeafView
+		mutex           *MutexView
+		progressTracker IndexerProgressTracker
 	}
 )
 
@@ -40,12 +46,14 @@ func NewZKCertificateRegistry(
 	sparseTree *SparseMerkleTree,
 	leafView *LeafView,
 	mutex *MutexView,
+	progressTracker IndexerProgressTracker,
 ) *ZKCertificateRegistry {
 	return &ZKCertificateRegistry{
-		metadata:   metadata,
-		sparseTree: sparseTree,
-		leafView:   leafView,
-		mutex:      mutex,
+		metadata:        metadata,
+		sparseTree:      sparseTree,
+		leafView:        leafView,
+		mutex:           mutex,
+		progressTracker: progressTracker,
 	}
 }
 
@@ -141,4 +149,9 @@ func (reg *ZKCertificateRegistry) GetRandomEmptyLeafProof(ctx context.Context) (
 	}
 
 	return proof, nil
+}
+
+// ProgressTracker returns the progress tracker of the registry.
+func (reg *ZKCertificateRegistry) ProgressTracker() IndexerProgressTracker {
+	return reg.progressTracker
 }


### PR DESCRIPTION
- Add polling indexation mode. Thus, the service can now be used with the evm rpc endpoint.
- Add a check to the query handler to see if the zk certificate registry is on chain head