### PR TITLE
feat: Add start block override configuration for contract indexing

### DIFF
--- a/cmd/galacticad-merkle/cmd/indexer/config.go
+++ b/cmd/galacticad-merkle/cmd/indexer/config.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 Galactica Network
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package indexer
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	pkgindexer "github.com/Galactica-corp/merkle-proof-service/pkg/indexer"
+)
+
+// parseContractConfigsToPackageType parses the contract configuration from viper
+// Supports both formats:
+// - Simple string array: ["0xAddr1", "0xAddr2"]
+// - Extended format: [{"address": "0xAddr1", "start_block": 12345}, "0xAddr2"]
+func parseContractConfigsToPackageType(rawConfigs []any) ([]pkgindexer.ContractConfig, error) {
+	var configs []pkgindexer.ContractConfig
+
+	for i, rawConfig := range rawConfigs {
+		switch v := rawConfig.(type) {
+		case string:
+			// Simple address string
+			if !common.IsHexAddress(v) {
+				return nil, fmt.Errorf("invalid address at index %d: %s", i, v)
+			}
+			configs = append(configs, pkgindexer.ContractConfig{
+				Address:    common.HexToAddress(v),
+				StartBlock: nil,
+			})
+
+		case map[string]any:
+			// Extended format with optional start_block
+			addressRaw, ok := v["address"]
+			if !ok {
+				return nil, fmt.Errorf("missing 'address' field at index %d", i)
+			}
+
+			addressStr, ok := addressRaw.(string)
+			if !ok {
+				return nil, fmt.Errorf("'address' must be a string at index %d", i)
+			}
+
+			if !common.IsHexAddress(addressStr) {
+				return nil, fmt.Errorf("invalid address at index %d: %s", i, addressStr)
+			}
+
+			config := pkgindexer.ContractConfig{
+				Address: common.HexToAddress(addressStr),
+			}
+
+			// Check for optional start_block
+			if startBlockRaw, exists := v["start_block"]; exists {
+				// Handle different numeric types that viper might return
+				var startBlock uint64
+				switch sb := startBlockRaw.(type) {
+				case float64:
+					startBlock = uint64(sb)
+				case int:
+					startBlock = uint64(sb)
+				case int64:
+					startBlock = uint64(sb)
+				case uint64:
+					startBlock = sb
+				default:
+					return nil, fmt.Errorf("'start_block' must be a number at index %d", i)
+				}
+				config.StartBlock = &startBlock
+			}
+
+			configs = append(configs, config)
+
+		default:
+			return nil, fmt.Errorf("invalid configuration format at index %d: must be string or object", i)
+		}
+	}
+
+	return configs, nil
+}

--- a/config/merkle-613419.yaml
+++ b/config/merkle-613419.yaml
@@ -30,7 +30,8 @@ indexer:
 zk_certificate_registry: []
 # V2 contracts (queue-based processing)
 zk_certificate_registry_v2:
-  - 0xf98E14C33c573c26Bb14d8ca71e1c8756727Be53 # kyc
+  - address: 0xf98E14C33c573c26Bb14d8ca71e1c8756727Be53 # kyc
+    start_block: 25600
   - 0xdD826498E46cb32259FDfb446965Ea734c5E28b7 # data
   - 0x721aB287a601EB7D115000880CC219d7EEF93eAD # dex
   - 0xb1124b8736520F58b80107c3DBB9B6c6512ad43b # gip6


### PR DESCRIPTION
# PR Title

feat: Add start block override configuration for contract indexing

# PR Description

## Summary

This PR adds the ability to specify custom start blocks for smart contracts in the configuration file, allowing the indexer to override the default `InitBlockHeight` retrieved from the contract.

## Problem

Previously, the merkle-proof-service would always start indexing from a contract's `InitBlockHeight()` method. In some cases, we need to specify a different starting block to:

- Skip historical data that's not relevant
- Start indexing from a specific known block
- Handle contracts where the InitBlockHeight might not be the desired starting point

## Solution

Implemented a flexible configuration format that supports both backward-compatible simple addresses and an extended format with optional start block overrides.

### Configuration Format

The configuration now supports two formats:

1. **Simple format** (backward compatible):

```yaml
zk_certificate_registry:
  - 0xa922eE97D068fd95d5692c357698F6Bf2C6fd8cE
  - 0xeE8Dd398919c2B11ac346F9f8CaF17ab9735950B
```

2. **Extended format** with start block override:

```yaml
zk_certificate_registry_v2:
  - address: 0xf98E14C33c573c26Bb14d8ca71e1c8756727Be53
    start_block: 25600  # Override the contract's InitBlockHeight
  - 0xdD826498E46cb32259FDfb446965Ea734c5E28b7  # Uses default InitBlockHeight
```

## Changes

### Core Changes

- Added `ContractConfig` struct to represent contract configuration with optional start block
- Updated configuration parsing to handle both simple and extended formats
- Modified registry initialization to use override values when specified
- Added logging to indicate when override blocks are being used

### Files Modified

- `pkg/indexer/application.go`: Added ContractConfig type and updated initialization logic
- `cmd/galacticad-merkle/cmd/indexer/start.go`: Updated configuration parsing functions
- `cmd/galacticad-merkle/cmd/indexer/config.go`: Added parsing helper functions
- `config/merkle-843843-with-overrides-example.yaml`: Example configuration file
- `config/merkle-613419.yaml`: Updated with start block override

## Testing

- [x] Verified backward compatibility with existing string array format
- [x] Tested extended format with start block overrides
- [x] Confirmed proper logging when overrides are used
- [x] Build passes without errors

## Example Usage

```yaml
# Mix of both formats in the same config
zk_certificate_registry_v2:
  - address: 0xf98E14C33c573c26Bb14d8ca71e1c8756727Be53
    start_block: 25600  # Start from block 25,600
  - 0xdD826498E46cb32259FDfb446965Ea734c5E28b7  # Use contract's InitBlockHeight
```

When an override is used, the logs will show:

```
INF using override start block address=0xf98E14C33c573c26Bb14d8ca71e1c8756727Be53 override_block=25600 contract_init_block=10000
```
